### PR TITLE
Add base configuration for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ For debugging, register into the [Renovate Dashboard](https://app.renovatebot.co
 |`integrations-base.json`|The base policies we apply to all repos.|
 |`integrations-automerge.json`|Default automerge policy.|
 |`integrations-scheduled.json`|The default updates schedule. Use if real-time updates are overwhelming in a specific repo.|
+
+## Android
+
+The base configuration for our Android repositories is defined in `android-base.json`.  

--- a/android-base.json
+++ b/android-base.json
@@ -1,0 +1,77 @@
+{
+  "extends": [
+    "config:base",
+    ":disableDependencyDashboard"
+  ],
+  "github-actions": {
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "groupName": "org.jetbrains.kotlin.*",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlin:",
+        "org.jetbrains.kotlin."
+      ]
+    },
+    {
+      "groupName": "org.jetbrains.kotlinx.*",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlinx:",
+        "org.jetbrains.kotlinx."
+      ]
+    },
+    {
+      "groupName": "androidx.compose.*",
+      "matchPackagePrefixes": [
+        "androidx.compose."
+      ]
+    },
+    {
+      "groupName": "androidx.*",
+      "matchPackagePrefixes": [
+        "androidx."
+      ]
+    },
+    {
+      "groupName": "com.android.*",
+      "matchPackagePrefixes": [
+        "com.android:",
+        "com.android."
+      ]
+    },
+    {
+      "groupName": "com.google.firebase.*",
+      "matchPackagePrefixes": [
+        "com.google.firebase."
+      ]
+    },
+    {
+      "groupName": "com.google.android.*",
+      "matchPackagePrefixes": [
+        "com.google.android:",
+        "com.google.android."
+      ]
+    },
+    {
+      "groupName": "com.fasterxml.jackson.*",
+      "matchPackagePrefixes": [
+        "com.fasterxml.jackson."
+      ]
+    },
+    {
+      "groupName": "org.commonmark.*",
+      "matchPackagePrefixes": [
+        "org.commonmark:",
+        "org.commonmark."
+      ]
+    }
+  ],
+  "reviewers": [
+    "team:android-hero"
+  ],
+  "schedule": [
+    "before 7am on Monday"
+  ],
+  "semanticCommits": "disabled"
+}


### PR DESCRIPTION
Adds the base Android configuration. What we already use in Todoist et al, plus some additional package rules and a weekly schedule.

Cc @jankratochvilcz for visibility. :)