### PR TITLE
Rules specific to Electron-based repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For debugging, register into the [Renovate Dashboard](https://app.renovatebot.co
 |`integrations-base.json`|The base policies we apply to all repos.|
 |`integrations-automerge.json`|Default automerge policy.|
 |`integrations-scheduled.json`|The default updates schedule. Use if real-time updates are overwhelming in a specific repo.|
+|`integrations-electron.json`|Rules specific to Electron-based repos.|
 
 ## Android
 

--- a/integrations-electron.json
+++ b/integrations-electron.json
@@ -1,0 +1,12 @@
+{
+    "packageRules": [
+        {
+          "matchPackageNames": ["electron"],
+          "allowedVersions": "<17"
+        },
+        {
+            "matchPackageNames": ["electron-builder"],
+            "allowedVersions": "<23"
+          }
+      ]
+}


### PR DESCRIPTION
@proxi can you add more and adjust the specific versioning constraints you want? Feel free to do this directly by pushing on the PR

https://docs.renovatebot.com/configuration-options/#matchpackageprefixes could come in handy.

Once we have this, let's merge and add this to the electron repo configs. I think this will make it easier to maintain consistency over time :-)