### PR TITLE
Less agressive devDependencies auto-merge

### DIFF
--- a/integrations-automerge.json
+++ b/integrations-automerge.json
@@ -5,6 +5,7 @@
             "automerge": true
         },
         {
+            "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
             "matchDepTypes": ["devDependencies"],
             "automerge": true
         }


### PR DESCRIPTION
@proxi the problem was that Electron is a devDependency, so I think we can be less aggressive about majors and also be more explicit about wanted updates for Electron https://github.com/Doist/renovate-config/pull/6