### PR TITLE
Constrains node versions to stable

### DIFF
--- a/integrations-base.json
+++ b/integrations-base.json
@@ -4,5 +4,11 @@
         "group:linters",
         "group:monorepos",
         "group:recommended"
+    ],
+    "packageRules": [
+        {
+            "matchPackageNames": ["node"],
+            "allowedVersions": "/^(16|18|20)(\\.|\\-)/"
+        }
     ]
 }


### PR DESCRIPTION
Resolves https://github.com/Doist/renovate-config/issues/8

We need to test this to see how it performs. I'm not entirely sure how Renovate's version matching works in docker files, but the regex should cover either way.