### PR TITLE
Adds stability days

### DIFF
--- a/integrations-base.json
+++ b/integrations-base.json
@@ -10,5 +10,6 @@
             "matchPackageNames": ["node"],
             "allowedVersions": "/^(16|18|20)(\\.|\\-)/"
         }
-    ]
+    ],
+    "stabilityDays": 3
 }

--- a/integrations-base.json
+++ b/integrations-base.json
@@ -11,5 +11,5 @@
             "allowedVersions": "/^(16|18|20)(\\.|\\-)/"
         }
     ],
-    "stabilityDays": 3
+    "stabilityDays": 5
 }


### PR DESCRIPTION
Based on [docs](https://docs.renovatebot.com/configuration-options/#stabilitydays) adding a delay of 3 days sounds to be a good idea as it could prevent us from ingesting broken releases of 3rd party dependencies