### PR TITLE
Add kotlin-base

### DIFF
--- a/kotlin-base.json
+++ b/kotlin-base.json
@@ -1,0 +1,24 @@
+{
+  "extends": [
+    "config:base",
+    ":disableDependencyDashboard"
+  ],
+  "github-actions": {
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "groupName": "org.jetbrains.kotlin:*",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlin:",
+        "org.jetbrains.kotlin."
+      ]
+    },
+    {
+      "groupName": "org.jetbrains.kotlin-wrappers:*",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlin-wrappers:"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
@rastislavvasko I considered splitting the kotlin-specific bits from `android-base` and then you could import both, but I don't know if that would break the schedule/reviewer bits. Thoughts?