### PR TITLE
Rebase stale Kotlin PRs by default

### DIFF
--- a/kotlin-base.json
+++ b/kotlin-base.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    ":rebaseStalePrs"
   ],
   "github-actions": {
     "enabled": false


### PR DESCRIPTION
Added this as a separate PR as it's a deviation from the current `android-base` config. Is this a bad idea?