### PR TITLE
Uniformize common configuration under doist-base

### DIFF
--- a/doist-base.json
+++ b/doist-base.json
@@ -1,0 +1,13 @@
+{
+    "extends": [
+        "config:base",
+        "group:linters",
+        "group:monorepos",
+        "group:recommended",
+        "schedule:weekdays"
+    ],
+    "github-actions": {
+        "enabled": false
+    },
+    "stabilityDays": 5
+}

--- a/frontend-base.json
+++ b/frontend-base.json
@@ -1,18 +1,15 @@
 {
     "extends": [
+        "github>doist/renovate-config:doist-base",
         "config:js-app",
-        "group:linters",
-        "group:monorepos",
         "group:postcss",
-        "group:recommended",
         "group:storybookMonorepo",
         ":automergeMinor",
         ":automergePr",
         ":automergeRequireAllStatusChecks",
         ":disablePeerDependencies",
         ":enableVulnerabilityAlertsWithLabel(security)",
-        ":label(dependencies)",
-        "schedule:weekdays"
+        ":label(dependencies)"
     ],
     "packageRules": [
         {
@@ -21,6 +18,5 @@
         }
     ],
     "enabledManagers": ["npm"],
-    "postUpdateOptions": ["npmDedupe"],
-    "stabilityDays": 5
+    "postUpdateOptions": ["npmDedupe"]
 }

--- a/integrations-base.json
+++ b/integrations-base.json
@@ -1,9 +1,6 @@
 {
     "extends": [
-        "config:base",
-        "group:linters",
-        "group:monorepos",
-        "group:recommended"
+        "github>doist/renovate-config:doist-base"
     ],
     "packageRules": [
         {
@@ -11,6 +8,5 @@
             "allowedVersions": "/^(16|18|20)(\\.|\\-)/"
         }
     ],
-    "stabilityDays": 5,
     "prCreation": "not-pending"
 }

--- a/kotlin-base.json
+++ b/kotlin-base.json
@@ -1,11 +1,7 @@
 {
   "extends": [
-    "config:base",
-    ":disableDependencyDashboard"
+    "github>doist/renovate-config:doist-base"
   ],
-  "github-actions": {
-    "enabled": false
-  },
   "packageRules": [
     {
       "groupName": "org.jetbrains.kotlin:*",


### PR DESCRIPTION
Includes:
1. Grouping of known linter/monorepo/recommended updates
2. Disable updates of GitHub Actions, since we pin them
3. Follow a week schedule, waiting 5 days to consider updates stable
4. Enable dependency dashboard in Kotlin (and Android) since all other platforms use it

@henningmu @rastislavvasko @jankratochvilcz I'd love your +1 on these above since even though I went with the “most commonly in use” options, they might lead to small changes in your codebases.