### PR TITLE
chore: Ignore the adaptivecards dependency

### DIFF
--- a/frontend-base.json
+++ b/frontend-base.json
@@ -18,5 +18,6 @@
         }
     ],
     "enabledManagers": ["npm"],
-    "postUpdateOptions": ["npmDedupe"]
+    "postUpdateOptions": ["npmDedupe"],
+    "ignoreDeps": ["adaptivecards"]
 }


### PR DESCRIPTION
Upgraded to 2.10 of the `adaptivecards` package breaks the rendering of the UI extensions. Until this can be looked into, we should avoid moving off 2.9.