### PR TITLE
chore: Ignore Ariakit updates

### DIFF
--- a/frontend-base.json
+++ b/frontend-base.json
@@ -19,5 +19,5 @@
     ],
     "enabledManagers": ["npm"],
     "postUpdateOptions": ["npmDedupe"],
-    "ignoreDeps": ["adaptivecards"]
+    "ignoreDeps": ["adaptivecards", "ariakit"]
 }


### PR DESCRIPTION
[Ariakit](https://github.com/ariakit/ariakit) should not be auto-updated, as prerelease tags can contain breaking changes.

Reference: https://github.com/Doist/reactist/issues/688