### PR TITLE
[Proposal] Remove `:disablePeerDependencies` from Frontend config

### DIFF
--- a/frontend-base.json
+++ b/frontend-base.json
@@ -7,7 +7,6 @@
         ":automergeMinor",
         ":automergePr",
         ":automergeRequireAllStatusChecks",
-        ":disablePeerDependencies",
         ":enableVulnerabilityAlertsWithLabel(security)",
         ":label(dependencies)"
     ],


### PR DESCRIPTION
Peer dependencies are production dependencies that are not exclusive to the package that is defining them, they might also be production dependencies of a parent package. However, since they are production dependencies for the package defining them, it makes sense that, in general, they are also updated by Renovate (there might be important bug fixes in them).

With the current configuration, peer dependencies are completely ignored, and given that we might be using SemVer ranges like `^x.y.z` in our peer dependencies, such dependencies might never be updated to later versions unless their versions are manually bumped. **I propose that we `:disablePeerDependencies` from our base Frontend configuration, and let Renovate update peer dependencies as well.**

Thoughts?