### PR TITLE
Fix offering `Jackson` updates incompatible with our `Android` `minSdk`

### DIFF
--- a/android-base.json
+++ b/android-base.json
@@ -49,6 +49,9 @@
       "groupName": "com.fasterxml.jackson.*",
       "matchPackagePrefixes": [
         "com.fasterxml.jackson."
+      ],
+      "matchUpdateTypes": [
+        "patch"
       ]
     },
     {


### PR DESCRIPTION
Fix offering `Jackson` updates incompatible with our `Android` `minSdk`

`Jackson 2.14+` requires the minimum `Android SDK` to be `26`. Currently used is `23`.  [`Jackson 2.14+` release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14#compatibility-min-android-sdk)

We'll keep accepting `2.13` patches in case they will be released.

Ref:
- https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14#compatibility-min-android-sdk
- https://docs.renovatebot.com/configuration-options/#matchupdatetypes