### PR TITLE
Keep ksp in sync with kotlin version

### DIFF
--- a/android-base.json
+++ b/android-base.json
@@ -10,7 +10,13 @@
       "groupName": "org.jetbrains.kotlinx.*",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlinx:",
-        "org.jetbrains.kotlinx."
+        "org.jetbrains.kotlinx.",
+      ]
+    },
+    {
+      "groupName": "org.jetbrains.kotlinx.*",
+      "matchPackagePatterns": [
+        "com.google.devtools.ksp"
       ]
     },
     {

--- a/android-base.json
+++ b/android-base.json
@@ -10,7 +10,7 @@
       "groupName": "org.jetbrains.kotlinx.*",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlinx:",
-        "org.jetbrains.kotlinx.",
+        "org.jetbrains.kotlinx."
       ]
     },
     {


### PR DESCRIPTION
Ref: https://github.com/android/architecture-templates/blob/eb8888b4658d64285840bd9cb8e9df0f8fc6471e/renovate.json#L29

Noticed recently that KSP version moved ahead of Kotlin version in Todoist-Android so this PR should prevent that in the future.