### PR TITLE
Keep Kotlin, KSP, and Compose Compiler updated in sync

### DIFF
--- a/android-base.json
+++ b/android-base.json
@@ -14,9 +14,11 @@
       ]
     },
     {
-      "groupName": "org.jetbrains.kotlinx.*",
+      "groupName": "org.jetbrains.kotlin.*",
       "matchPackagePatterns": [
-        "com.google.devtools.ksp"
+        "org.jetbrains.kotlin.*",
+        "com.google.devtools.ksp",
+        "androidx.compose.compiler:compiler"
       ]
     },
     {


### PR DESCRIPTION
Since Renovate decided to create a PR with a new KSP update anyway, the previous rule didn't work and I realized I tied it to kotlinx instead of kotlin. 🤔 Although even that didn't work.