### PR TITLE
Exclude overlapping packages from less-specific package rule

### DIFF
--- a/android-base.json
+++ b/android-base.json
@@ -24,13 +24,21 @@
     {
       "groupName": "androidx.compose.*",
       "matchPackagePrefixes": [
-        "androidx.compose."
+        "androidx.compose.",
+        "androidx.wear.compose."
+      ],
+      "excludePackagePrefixes": [
+        "androidx.compose.compiler"
       ]
     },
     {
       "groupName": "androidx.*",
       "matchPackagePrefixes": [
         "androidx."
+      ],
+      "excludePackagePrefixes": [
+        "androidx.compose.",
+        "androidx.wear.compose."
       ]
     },
     {


### PR DESCRIPTION
Include wear compose packages in androidx.compose.* group.

Because we specify a group for `androidx.` package prefixes, it seems to be overriding any other groups with more specific packages that also start with `androidx.` like `androidx.compose`, evidenced by the fact that we've never had Renovate create a PR with [Update androidx.compose](https://github.com/Doist/Todoist-Android/pulls?q=is%3Apr+sort%3Aupdated-desc+Update+androidx.compose+is%3Amerged+) as a title.

Also pre-emptively doing the same for `androidx.compose.compiler` since we want Renovate to update it when it updates Kotlin and KSP so it all remains in sync.