### PR TITLE
Request review from Android team instead of Android Hero

### DIFF
--- a/android-base.json
+++ b/android-base.json
@@ -76,7 +76,7 @@
     }
   ],
   "reviewers": [
-    "team:android-hero"
+    "team:android"
   ],
   "schedule": [
     "before 7am on Monday"


### PR DESCRIPTION
Changes the default reviewer from @Doist/android-hero to @Doist/android, i.e. using the roulette as for our non-SP PRs. More context in https://twist.com/a/1585/ch/405759/t/5806556/c/89214462.