### PR TITLE
Add separate group for `com.android.billingclient`

### DIFF
--- a/android-base.json
+++ b/android-base.json
@@ -42,10 +42,20 @@
       ]
     },
     {
+      "groupName": "com.android.billingclient",
+      "matchPackagePrefixes": [
+        "com.android.billingclient:",
+        "com.android.billingclient."
+      ]
+    },
+    {
       "groupName": "com.android.*",
       "matchPackagePrefixes": [
         "com.android:",
         "com.android."
+      ],
+      "excludePackagePrefixes": [
+        "com.android.billingclient"
       ]
     },
     {


### PR DESCRIPTION
This PR creates a separate group for `com.android.billingclient` to be able to have separate renovate PRs for billing client.