### PR TITLE
Remove unnecessary package prefix

### DIFF
--- a/android-base.json
+++ b/android-base.json
@@ -44,8 +44,7 @@
     {
       "groupName": "com.android.billingclient",
       "matchPackagePrefixes": [
-        "com.android.billingclient:",
-        "com.android.billingclient."
+        "com.android.billingclient:"
       ]
     },
     {


### PR DESCRIPTION
This PR removes unnecessary package prefix which was added in https://github.com/Doist/renovate-config/pull/32.