### PR TITLE
chore: Skip minimum release age for security updates

### DIFF
--- a/doist-base.json
+++ b/doist-base.json
@@ -10,5 +10,11 @@
     "github-actions": {
         "enabled": false
     },
-    "minimumReleaseAge": "5 days"
+    "minimumReleaseAge": "5 days",
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["security"],
+            "minimumReleaseAge": "0 days"
+        }
+    ]
 }


### PR DESCRIPTION
Gemini actually tells me this is the default behavior:

> By default, Renovate automatically bypasses the minimumReleaseAge setting for all pull requests triggered by vulnerability alerts. This ensures that critical security updates are not delayed. However, you can explicitly configure this behavior for granular control and clarity using packageRules.

However, I've been unable to find clear documentation on this.

Seeing as this is _not_ working on Aist, let's see if being explicit about it helps.