### PR TITLE
Revert "chore: Skip minimum release age for security updates"

### DIFF
--- a/doist-base.json
+++ b/doist-base.json
@@ -10,11 +10,5 @@
     "github-actions": {
         "enabled": false
     },
-    "minimumReleaseAge": "5 days",
-    "packageRules": [
-        {
-            "matchUpdateTypes": ["security"],
-            "minimumReleaseAge": "0 days"
-        }
-    ]
+    "minimumReleaseAge": "5 days"
 }


### PR DESCRIPTION
Reverts Doist/renovate-config#35

As suspected, this makes no difference… Which means it also didn't solve the issue. 😅 