### PR TITLE
chore: prioritize @doist scoped packages in Renovate

### DIFF
--- a/doist-base.json
+++ b/doist-base.json
@@ -11,10 +11,6 @@
         {
             "matchManagers": ["github-actions"],
             "enabled": false
-        },
-        {
-            "matchPackageNames": ["@doist/**"],
-            "prPriority": 5
         }
     ],
     "minimumReleaseAge": "5 days"

--- a/doist-base.json
+++ b/doist-base.json
@@ -11,6 +11,10 @@
         {
             "matchManagers": ["github-actions"],
             "enabled": false
+        },
+        {
+            "matchPackageNames": ["@doist/**"],
+            "prPriority": 5
         }
     ],
     "minimumReleaseAge": "5 days"

--- a/frontend-base.json
+++ b/frontend-base.json
@@ -14,6 +14,10 @@
         {
             "matchPackageNames": ["@types/react", "@types/react-dom"],
             "groupName": "react monorepo"
+        },
+        {
+            "matchPackageNames": ["@doist/**"],
+            "prPriority": 5
         }
     ],
     "enabledManagers": ["npm"],

--- a/integrations-base.json
+++ b/integrations-base.json
@@ -6,6 +6,10 @@
         {
             "matchPackageNames": ["node"],
             "allowedVersions": "/^(16|18|20)(\\.|\\-)/"
+        },
+        {
+            "matchPackageNames": ["@doist/**"],
+            "prPriority": 5
         }
     ],
     "prCreation": "not-pending"


### PR DESCRIPTION
## Overview

`@doist` scoped packages are our internal libraries, so keeping them up to date is higher priority than third-party dependencies. This adds a `prPriority: 5` rule to `doist-base.json` so Renovate creates PRs for `@doist/**` packages before other updates when multiple are pending.

### Reference

- [Renovate `prPriority` docs](https://docs.renovatebot.com/configuration-options/#prpriority)
- [Doist/todoist-web#16619](https://github.com/Doist/todoist-web/pull/16619) (local precedent)

## Test plan

- Verify next scheduled Renovate run creates `@doist` PRs before third-party ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)