### PR TITLE
Update kotlin renovate config

### DIFF
--- a/android-base.json
+++ b/android-base.json
@@ -8,17 +8,8 @@
       "enabled": false
     },
     {
-      "groupName": "org.jetbrains.kotlinx.*",
-      "matchPackagePrefixes": [
-        "org.jetbrains.kotlinx:",
-        "org.jetbrains.kotlinx."
-      ]
-    },
-    {
       "groupName": "org.jetbrains.kotlin.*",
       "matchPackagePatterns": [
-        "org.jetbrains.kotlin.*",
-        "com.google.devtools.ksp",
         "androidx.compose.compiler:compiler"
       ]
     },

--- a/kotlin-base.json
+++ b/kotlin-base.json
@@ -4,16 +4,39 @@
   ],
   "packageRules": [
     {
-      "groupName": "org.jetbrains.kotlin:*",
+      "groupName": "com.doist.kmp",
+      "matchPackagePrefixes": [
+        "com.doist.kmp",
+        "com.doist:kmp-"
+      ],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "groupName": "org.jetbrains.kotlin.*",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlin:",
-        "org.jetbrains.kotlin."
+        "org.jetbrains.kotlin.",
+        "com.google.devtools.ksp"
+      ]
+    },
+    {
+      "groupName": "org.jetbrains.kotlinx.*",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlinx:",
+        "org.jetbrains.kotlinx."
       ]
     },
     {
       "groupName": "org.jetbrains.kotlin-wrappers:*",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlin-wrappers:"
+      ]
+    },
+    {
+      "groupName": "detekt",
+      "matchPackagePrefixes": [
+        "dev.detekt",
+        "io.gitlab.arturbosch.detekt"
       ]
     }
   ]


### PR DESCRIPTION
This PR updates kotlin related configs:

- `kotlin-base`: the Kotlin ecosystem groups moved here from `android-base` so every Kotlin repo shares them: `org.jetbrains.kotlin.*` (now also matches KSP), `org.jetbrains.kotlinx.*`, and a new `detekt` group (`dev.detekt` plus the legacy `io.gitlab.arturbosch.detekt`).
- `kotlin-base`: new `com.doist.kmp` group covering the KMP convention plugin and the `com.doist:kmp-*` artifacts, with `minimumReleaseAge` set to `0 days`. These are our own releases, so the global 5-day cooldown from `doist-base` would only slow down the rollout.
- `android-base`: dropped the rules that moved to `kotlin-base`. It extends `kotlin-base`, so nothing changes for Android repos; only the Android specifics stay, with the Compose compiler still riding along with the Kotlin group.