### PR TITLE
Exclude kotlinx-datetime `0.6.x-compat` artifacts

### DIFF
--- a/kotlin-base.json
+++ b/kotlin-base.json
@@ -27,6 +27,10 @@
       ]
     },
     {
+      "matchPackageNames": ["org.jetbrains.kotlinx:kotlinx-datetime"],
+      "allowedVersions": "!/-0\\.6\\.x-compat$/"
+    },
+    {
       "groupName": "org.jetbrains.kotlin-wrappers:*",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlin-wrappers:"


### PR DESCRIPTION
This PR excludes `-0.6.x-compat` versions for kotlinx-datetime.

Since 0.7.0, every kotlinx-datetime release ships a `-0.6.x-compat` twin: a binary-compatible build that keeps the pre-0.7 API (`kotlinx.datetime.Instant` and `Clock`, which moved to `kotlin.time`). Both Gradle and Maven version ordering rank the extra `-0.6.x-compat` qualifier above the plain release, so Renovate proposes the compat artifact as the latest version.

